### PR TITLE
Enhancement/return strategy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simbld-http"
-version = "0.4.1"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
 authors = ["Simon Bullado <s_bullado51@hotmail.com>"]
@@ -20,16 +20,12 @@ serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.66"
 actix-web = "4.9.0"
 strum = "0.27.1"
-strum_macros = { version = "0.26.4" }
+strum_macros = { version = "0.27.1" }
 futures-util = "0.3"
 actix-service = "2.0"
-serde_urlencoded = "0.7.1"
-url = "2.1.0"
-inflector = { version = "0.11", package = "Inflector" }
 uuid = { version = "1.11.0", features = ["v4"] }
 log = "0.4.8"
 chrono = "0.4.39"
-paste = "1.0.15"
 lazy_static = "1.5.0"
 thiserror = "2.0.11"
 tokio = "1.42.0"

--- a/src/helpers/unified_tuple_helper.rs
+++ b/src/helpers/unified_tuple_helper.rs
@@ -73,6 +73,22 @@ impl UnifiedTuple {
             },
         })
     }
+
+    pub fn new(
+        standard_code: u16,
+        standard_name: &'static str,
+        unified_description: &'static str,
+        internal_code: u16,
+        internal_name: &'static str,
+    ) -> Self {
+        Self {
+            standard_code,
+            standard_name,
+            unified_description,
+            internal_code: Some(internal_code),
+            internal_name: Some(internal_name),
+        }
+    }
 }
 
 /// Implements automatic conversion from ResponsesTypes to UnifiedTuple.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@ pub use helpers::unified_middleware_helper::UnifiedMiddleware;
 pub use mocks::mock_responses::MockResponses;
 
 // External crates re-exported for convenience
-pub use inflector::Inflector;
 pub use serde_json::{json, Value};
 
 // Public exports for response modules

--- a/src/responses/client.rs
+++ b/src/responses/client.rs
@@ -94,11 +94,11 @@ mod tests {
         );
         assert_eq!(
             ResponsesClientCodes::from_internal_code(401),
-            Some(ResponsesClientCodes::BadRequest)
+            Some(ResponsesClientCodes::Unauthorized)
         );
         assert_eq!(
             ResponsesClientCodes::from_internal_code(441),
-            Some(ResponsesClientCodes::BadRequest)
+            Some(ResponsesClientCodes::OverDataQuota)
         );
         assert_eq!(ResponsesClientCodes::from_internal_code(9999), None);
     }


### PR DESCRIPTION
## Résumé par Sourcery

Amélioration de la gestion des réponses HTTP et de la sérialisation dans la bibliothèque simbld-http, introduction de méthodes de transformation JSON plus flexibles et mise à jour de la gestion des codes de réponse.

Nouvelles fonctionnalités :
- Ajout de nouvelles méthodes de transformation JSON pour les réponses HTTP avec des métadonnées et des capacités de filtrage
- Introduction d'une nouvelle méthode pour créer des réponses JSON avec des données dynamiques

Corrections de bugs :
- Correction du mappage de code interne pour les codes d'erreur du client
- Correction de la logique de sérialisation et de transformation du code de réponse

Améliorations :
- Refactorisation de la gestion des codes de réponse pour fournir des représentations de tuples plus détaillées et flexibles
- Mise à jour de la struct UnifiedTuple pour prendre en charge des informations de code de réponse plus complètes
- Amélioration du mappage des codes d'erreur et des méthodes de conversion

Tâches :
- Mise à jour de la version de la bibliothèque vers 1.0.0
- Suppression des dépendances inutilisées de Cargo.toml

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance HTTP response handling and serialization in the simbld-http library, introducing more flexible JSON transformation methods and updating response code handling

New Features:
- Add new JSON transformation methods for HTTP responses with metadata and filtering capabilities
- Introduce a new method to create JSON responses with dynamic data

Bug Fixes:
- Fix internal code mapping for client error codes
- Correct response code serialization and transformation logic

Enhancements:
- Refactor response code handling to provide more detailed and flexible tuple representations
- Update UnifiedTuple struct to support more comprehensive response code information
- Improve error code mapping and conversion methods

Chores:
- Update library version to 1.0.0
- Remove unused dependencies from Cargo.toml

</details>